### PR TITLE
OKE --> OKD

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This document uses the following variables to ensure that upstream and downstrea
 | project-short | Forklift | MTV |
 | project-version | 2.0-beta | 2.0-beta |
 | virt | KubeVirt | OpenShift Virtualization |
-| ocp | OpenShift Kubernetes Engine | Red Hat OpenShift Container Platform |
+| ocp | OKD | Red Hat OpenShift Container Platform |
 | ocp-version   | 4.6 | 4.6 |
 | ocp-short | OKE | OCP |
 


### PR DESCRIPTION
OpenShift Kubernetes Engine is a Downstream offering by Red Hat. 
The Upstream distribution for OpenShift (both OKE and OCP) is OKD ( https://www.okd.io/ )
IMHO this is the correct way to express it. Could we please consider this change?