### PR TITLE
BZ1945328: Delete OAuthClient in CLI uninstall

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/uninstalling-mtv-cli.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/uninstalling-mtv-cli.adoc
@@ -24,5 +24,12 @@ $ oc delete project {namespace}
 +
 [source,terminal]
 ----
-$ oc get crd -o name | grep "forklift.konveyor.io" | xargs oc delete
+$ oc get crd -o name | grep 'forklift' | xargs oc delete
+----
+
+. Delete the OAuthClient:
++
+[source,terminal]
+----
+$ oc get oauthclient -o name | grep 'forklift' | xargs oc delete
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1945328

Preview build: https://606593475a2bae000785d712--distracted-shaw-5cd1c3.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#uninstalling-mtv-cli_forklift

Ready for QE