### PR TITLE
Replace busybox with UBI for VDDK image build

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/adding-vddk-to-mtv.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/adding-vddk-to-mtv.adoc
@@ -45,7 +45,7 @@ $ tar -xzf VMware-vix-disklib-<version>.x86_64.tar.gz
 [source,terminal]
 ----
 $ cat > Dockerfile <<EOF
-FROM busybox:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY vmware-vix-disklib-distrib /vmware-vix-disklib-distrib
 RUN mkdir -p /opt
 ENTRYPOINT ["cp", "-r", "/vmware-vix-disklib-distrib", "/opt"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1946273

The Universal Base Image (UBI) provided by Red Hat is scanned for vulnerabilities, so using it ensures better security.

Build preview: https://deploy-preview-94--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#adding-vddk-to-mtv_forklift