### PR TITLE
Update downstream product short name. Use apiVersion v1beta1.

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/common-attributes.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/common-attributes.adoc
@@ -15,9 +15,9 @@
 :ocp: OpenShift{nbsp}Container{nbsp}Platform
 :ocp-version: 4.7
 :ocp-short: OCP
-:operator: rhmtv-operator
+:operator: mtv-operator
 // If namespace must be formatted with backticks, use + instead.
-:namespace: openshift-rhmtv
+:namespace: openshift-mtv
 
 :abstract: {The} {project-first} enables you to migrate virtual machines from VMware vSphere to {virt} running on {ocp}.
 :title: Installing and using {the-lc} {project-full}

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/installing-mtv-cli.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/installing-mtv-cli.adoc
@@ -131,7 +131,7 @@ endif::[]
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:
   name: forklift-controller

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/migrating-virtual-machines-cli.adoc
@@ -69,7 +69,7 @@ EOF
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: virt.konveyor.io/v1alpha1
+apiVersion: forklfit.konveyor.io/v1beta1
 kind: Provider
 metadata:
   name: vmware-provider
@@ -90,7 +90,7 @@ EOF
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: virt.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Plan
 metadata:
   name: <plan_name> <1>
@@ -138,7 +138,7 @@ EOF
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: virt.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Migration
 metadata:
   name: <migration_name> <1>

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/migrating-virtual-machines-cli.adoc
@@ -69,7 +69,7 @@ EOF
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: forklfit.konveyor.io/v1beta1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provider
 metadata:
   name: vmware-provider

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/modules/uninstalling-mtv-ui.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/modules/uninstalling-mtv-ui.adoc
@@ -18,7 +18,7 @@ ifeval::["{build}" == "upstream"]
 . Enter `forklift` in the *Search* field to locate the {namespace} project.
 endif::[]
 ifeval::["{build}" == "downstream"]
-. Enter `rhmtv` in the *Search* field to locate the {namespace} project.
+. Enter `mtv` in the *Search* field to locate the {namespace} project.
 endif::[]
 . On the right side of the project, select *Delete Project* from the {kebab}.
 . In the *Delete Project* pane, enter the project name and click *Delete*.


### PR DESCRIPTION
The API version of forklift has been promoted to v1beta1, so we need to reflect it in examples.
The downstream product short name has been changed to MTV, so we need to update the configuration.