### PR TITLE
bz1969852-oauth-delete

### DIFF
--- a/documentation/modules/uninstalling-mtv-cli.adoc
+++ b/documentation/modules/uninstalling-mtv-cli.adoc
@@ -31,5 +31,5 @@ $ oc get crd -o name | grep 'forklift' | xargs oc delete
 +
 [source,terminal]
 ----
-$ oc get oauthclient -o name | grep 'forklift' | xargs oc delete
+$ oc delete oauthclient/forklift-ui
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1969852

Preview: https://deploy-preview-143--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#uninstalling-mtv-cli_forklift