### PR TITLE
BZ1996971: Remove metrics and Prometheus from must-gather module

### DIFF
--- a/documentation/modules/using-must-gather.adoc
+++ b/documentation/modules/using-must-gather.adoc
@@ -14,8 +14,6 @@ You can gather data for a specific namespace, migration plan, or virtual machine
 If you specify a non-existent resource in the filtered `must-gather` command, no archive file is created.
 ====
 
-You can collect metrics data for a 24-hour period and view the data with the Prometheus console.
-
 .Prerequisites
 
 * You must be logged in to the {virt} cluster as a user with the `cluster-admin` role.
@@ -59,39 +57,3 @@ $ oc adm must-gather --image={must-gather} \
   -- VM=<vm_id> NS=<namespace> /usr/bin/targeted <1>
 ----
 <1> Specify the VM _ID_ as it appears in the `Plan` CR.
-
-.Collecting and viewing metrics data
-
-. Navigate to the directory where you want to store the `must-gather` data.
-. Run the `oc adm must-gather` command with the `gather_metrics_dump` script to gather data for the past 24 hours:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image={must-gather} \
-  -- /usr/bin/gather_metrics_dump
-----
-+
-This operation can take a long time. The data is saved as `/must-gather/metrics/prom_data.tar.gz`.
-
-. To view the data with the Prometheus console, create a local Prometheus instance:
-+
-[source,terminal]
-----
-$ make prometheus-run
-----
-+
-The command outputs the Prometheus URL:
-+
-.Output
-[source,terminal]
-----
-Started Prometheus on http://localhost:9090
-----
-
-. Launch a web browser and navigate to the Prometheus URL to view the data.
-. After you have viewed the data, delete the Prometheus instance and data:
-+
-[source,terminal]
-----
-$ make prometheus-cleanup
-----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1996971

Preview: https://deploy-preview-195--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#using-must-gather_forklift