### PR TITLE
BZ2010070: Fix startingCSV

### DIFF
--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -87,7 +87,7 @@ spec:
   name: {operator}
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "konveyor-forklift-operator.v{project-z-version}"
+  startingCSV: "konveyor-forklift-operator.{project-z-version}"
 EOF
 ----
 endif::[]
@@ -107,7 +107,7 @@ spec:
   name: {operator}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "mtv-operator.v{project-z-version}"
+  startingCSV: "mtv-operator.{project-z-version}"
 EOF
 ----
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2010070

"v" removed from startingCSV field for both upstream and downstream docs

Preview: https://deploy-preview-215--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#installing-mtv-operator_forklift