### PR TITLE
BZ2022654: Deleting plan does not delete temporary resources

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -92,24 +92,22 @@ include::modules/adding-source-provider.adoc[leveloffset=+3]
 include::modules/adding-source-provider.adoc[leveloffset=+3]
 :rhv!:
 :mtv:
-include::modules/selecting-migration-network-for-source-provider.adoc[leveloffset=+4]
-
+include::modules/selecting-migration-network-for-source-provider.adoc[leveloffset=+3]
 include::modules/adding-virt-provider.adoc[leveloffset=+3]
-include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+3]
 
 include::modules/creating-network-mapping.adoc[leveloffset=+2]
 include::modules/creating-storage-mapping.adoc[leveloffset=+2]
 include::modules/creating-migration-plan.adoc[leveloffset=+2]
 include::modules/running-migration-plan.adoc[leveloffset=+2]
-include::modules/canceling-migration-ui.adoc[leveloffset=+3]
-
 include::modules/migration-plan-options-ui.adoc[leveloffset=+2]
 include::modules/changing-precopy-intervals-ui.adoc[leveloffset=+3]
+include::modules/canceling-migration-ui.adoc[leveloffset=+2]
 
-[id="migrating-virtual-machines-cli"]
-== Migrating virtual machines from the command line interface
+[id="migrating-virtual-machines-from-cli"]
+== Migrating virtual machines from the command line
 
-You can migrate virtual machines (VMs) to {virt} from the command line (CLI).
+You can migrate virtual machines to {virt} from the command line.
 
 [IMPORTANT]
 ====
@@ -117,7 +115,7 @@ You must ensure that all xref:prerequisites[prerequisites] are met.
 ====
 
 include::modules/migrating-virtual-machines-cli.adoc[leveloffset=+2]
-include::modules/canceling-migration-cli.adoc[leveloffset=+3]
+include::modules/canceling-migration-cli.adoc[leveloffset=+2]
 
 include::modules/upgrading-mtv-ui.adoc[leveloffset=+1]
 

--- a/documentation/modules/migration-plan-options-ui.adoc
+++ b/documentation/modules/migration-plan-options-ui.adoc
@@ -26,6 +26,8 @@ The *Archive* option is irreversible. However, you can duplicate an archived pla
 [NOTE]
 ====
 The *Delete* option is irreversible.
+
+Deleting a migration plan does not remove temporary resources such as `Importer` pods, `Conversion` pods, config maps, secrets, failed VMs, and data volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018974[*BZ#2018974*]) You must archive a migration plan before deleting it in order to clean up the temporary resources.
 ====
 
 * *View details*: Display the details of a migration plan.

--- a/documentation/modules/rn-2.2.adoc
+++ b/documentation/modules/rn-2.2.adoc
@@ -39,3 +39,7 @@ Retaining the `Importer` pod for debug purposes causes warm migration to hang du
 As a temporary workaround, the `Importer` pod is removed at the end of the precopy stage so that the precopy succeeds. However, this means that the `Importer` pod log is not retained after warm migration is complete. You can only view the `Importer` pod log by using the `oc logs -f <cdi-importer_pod>` command during the precopy stage.
 
 This issue only affects the `Importer` pod log and warm migration. Cold migration and the `virt-v2v` logs are not affected.
+
+.Deleting migration plan does not remove temporary resources.
+
+Deleting a migration plan does not remove temporary resources such as `Importer` pods, `Conversion` pods, config maps, secrets, failed VMs and data volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018974[*BZ#2018974*]) You must archive a migration plan before deleting it in order to clean up the temporary resources.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2022654

Previews:
https://deploy-preview-244--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#migration-plan-options-ui_forklift

https://deploy-preview-244--forklift-documentation.netlify.app/documentation/doc-release_notes/master/#known-issues-22_forklift