### PR TITLE
BZ2050738: Obtaining the SHA-1 fingerprint of a vCenter host" section - Fix vCenter host address

### DIFF
--- a/documentation/modules/obtaining-vmware-fingerprint.adoc
+++ b/documentation/modules/obtaining-vmware-fingerprint.adoc
@@ -20,7 +20,7 @@ $ openssl s_client \
     | openssl x509 -fingerprint -noout -in /dev/stdin \
     | cut -d '=' -f 2
 ----
-<1> Specify the address of the vCenter host with an FQDN or an IP address.
+<1> Specify the IP address or FQDN of the vCenter host.
 +
 .Example output
 +

--- a/documentation/modules/obtaining-vmware-fingerprint.adoc
+++ b/documentation/modules/obtaining-vmware-fingerprint.adoc
@@ -15,12 +15,12 @@ You must obtain the SHA-1 fingerprint of a vCenter host in order to create a `Se
 [source,terminal]
 ----
 $ openssl s_client \
-    -connect <www.example.com>:443 \ <1>
+    -connect <vcenter_host>:443 \ <1>
     < /dev/null 2>/dev/null \
     | openssl x509 -fingerprint -noout -in /dev/stdin \
     | cut -d '=' -f 2
 ----
-<1> Specify the vCenter name.
+<1> Specify the address of the vCenter host with an FQDN or an IP address.
 +
 .Example output
 +


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2050738.

Updated user-replaceable text to indicate that an FQDN or IP address is necessary.

Preview: https://deploy-preview-283--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#obtaining-vmware-fingerprint_forklift
