### PR TITLE
2037652 - NFS StorageProfile resource should be edited with accessModes and volumeMode values before migration

### DIFF
--- a/documentation/modules/accessing-logs-cli.adoc
+++ b/documentation/modules/accessing-logs-cli.adoc
@@ -18,7 +18,7 @@ If you specify a non-existent resource in the filtered `must-gather` command, no
 .Prerequisites
 
 * You must be logged in to the {virt} cluster as a user with the `cluster-admin` role.
-* You must have the link:https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[{ocp} CLI (`oc`)] installed.
+* You must have the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[{ocp} CLI (`oc`)] installed.
 
 .Procedure
 

--- a/documentation/modules/accessing-logs-cli.adoc
+++ b/documentation/modules/accessing-logs-cli.adoc
@@ -18,7 +18,7 @@ If you specify a non-existent resource in the filtered `must-gather` command, no
 .Prerequisites
 
 * You must be logged in to the {virt} cluster as a user with the `cluster-admin` role.
-* You must have the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[{ocp} CLI (`oc`)] installed.
+* You must have the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/cli_tools/openshift-cli-oc#cli-getting-started[{ocp} CLI (`oc`)] installed.
 
 .Procedure
 

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -10,7 +10,7 @@ You can add {a-virt} provider to the {project-short} web console in addition to 
 
 .Prerequisites
 
-* You must have {a-virt} link:https://docs.openshift.com/container-platform/{ocp-version}/authentication/using-service-accounts-in-applications.html[service account token] with `cluster-admin` privileges.
+* You must have {a-virt} link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/authentication/using-service-accounts-in-applications.html[service account token] with `cluster-admin` privileges.
 
 .Procedure
 

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -10,7 +10,7 @@ You can add {a-virt} provider to the {project-short} web console in addition to 
 
 .Prerequisites
 
-* You must have {a-virt} link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/authentication/using-service-accounts-in-applications.html[service account token] with `cluster-admin` privileges.
+* You must have {a-virt} link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/authentication_and_authorization/using-service-accounts[service account token] with `cluster-admin` privileges.
 
 .Procedure
 

--- a/documentation/modules/creating-network-mapping.adoc
+++ b/documentation/modules/creating-network-mapping.adoc
@@ -11,7 +11,7 @@ You can create one or more network mappings by using the {project-short} web con
 .Prerequisites
 
 * Source and target providers added to the web console.
-* If you map more than one source and target network, each additional {virt} network requires its own link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition].
+* If you map more than one source and target network, each additional {virt} network requires its own link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-creating-network-attachment-definition[network attachment definition].
 
 .Procedure
 

--- a/documentation/modules/creating-network-mapping.adoc
+++ b/documentation/modules/creating-network-mapping.adoc
@@ -11,7 +11,7 @@ You can create one or more network mappings by using the {project-short} web con
 .Prerequisites
 
 * Source and target providers added to the web console.
-* If you map more than one source and target network, each additional {virt} network requires its own link:https://docs.openshift.com/container-platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition].
+* If you map more than one source and target network, each additional {virt} network requires its own link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition].
 
 .Procedure
 

--- a/documentation/modules/creating-vddk-image.adoc
+++ b/documentation/modules/creating-vddk-image.adoc
@@ -17,7 +17,7 @@ Storing the VDDK image in a public registry might violate the VMware license ter
 
 .Prerequisites
 
-* link:https://docs.openshift.com/container-platform/{ocp-version}/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html[{ocp} image registry] or a secure link:https://docs.openshift.com/container-platform/{ocp-version}/registry/registry-options.html[external registry].
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html[{ocp} image registry] or a secure link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/registry/registry-options.html[external registry].
 * `podman` installed.
 * If you are using an external registry, {virt} must be able to access it.
 

--- a/documentation/modules/creating-vddk-image.adoc
+++ b/documentation/modules/creating-vddk-image.adoc
@@ -17,7 +17,7 @@ Storing the VDDK image in a public registry might violate the VMware license ter
 
 .Prerequisites
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html[{ocp} image registry] or a secure link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/registry/registry-options.html[external registry].
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/registry/setting-up-and-configuring-the-registry#configuring-registry-storage-baremetal[{ocp} image registry].
 * `podman` installed.
 * If you are using an external registry, {virt} must be able to access it.
 

--- a/documentation/modules/network-prerequisites.adoc
+++ b/documentation/modules/network-prerequisites.adoc
@@ -10,7 +10,7 @@ The following prerequisites apply to all migrations:
 
 * IP addresses, VLANs, and other network configuration settings must not be changed before or after migration. The MAC addresses of the virtual machines are preserved during migration.
 * The network connections between the source environment, the {virt} cluster, and the replication repository must be reliable and uninterrupted.
-* If you are mapping more than one source and destination network, you must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network.
+* If you are mapping more than one source and destination network, you must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network.
 
 [id="ports_{context}"]
 == Ports

--- a/documentation/modules/network-prerequisites.adoc
+++ b/documentation/modules/network-prerequisites.adoc
@@ -10,7 +10,7 @@ The following prerequisites apply to all migrations:
 
 * IP addresses, VLANs, and other network configuration settings must not be changed before or after migration. The MAC addresses of the virtual machines are preserved during migration.
 * The network connections between the source environment, the {virt} cluster, and the replication repository must be reliable and uninterrupted.
-* If you are mapping more than one source and destination network, you must create a link:https://docs.openshift.com/container-platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network.
+* If you are mapping more than one source and destination network, you must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network.
 
 [id="ports_{context}"]
 == Ports

--- a/documentation/modules/rn-2.0.adoc
+++ b/documentation/modules/rn-2.0.adoc
@@ -55,7 +55,7 @@ The QEMU guest agent is not installed on migrated VMs. Workaround: Install the Q
 
 .Network map displays a "Destination network not found" error
 
-If the network map remains in a `NotReady` state and the `NetworkMap` manifest displays a `Destination network not found` error, the cause is a missing network attachment definition. You must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network before you create the network map. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971259[*BZ#1971259*])
+If the network map remains in a `NotReady` state and the `NetworkMap` manifest displays a `Destination network not found` error, the cause is a missing network attachment definition. You must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network before you create the network map. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971259[*BZ#1971259*])
 
 .Warm migration gets stuck during third precopy
 

--- a/documentation/modules/rn-2.0.adoc
+++ b/documentation/modules/rn-2.0.adoc
@@ -55,7 +55,7 @@ The QEMU guest agent is not installed on migrated VMs. Workaround: Install the Q
 
 .Network map displays a "Destination network not found" error
 
-If the network map remains in a `NotReady` state and the `NetworkMap` manifest displays a `Destination network not found` error, the cause is a missing network attachment definition. You must create a link:https://docs.openshift.com/container-platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network before you create the network map. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971259[*BZ#1971259*])
+If the network map remains in a `NotReady` state and the `NetworkMap` manifest displays a `Destination network not found` error, the cause is a missing network attachment definition. You must create a link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-network-attachment-definition[network attachment definition] for each additional destination network before you create the network map. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971259[*BZ#1971259*])
 
 .Warm migration gets stuck during third precopy
 

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -10,7 +10,7 @@
 
 [NOTE]
 ====
-If the {virt} storage does not support link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/storage/index#dynamic-provisioning[dynamic provisioning], you must apply the following settings:
+If the {virt} storage does not support link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/dynamic-provisioning[dynamic provisioning], you must apply the following settings:
 
 * `Filesystem` volume mode
 +
@@ -19,7 +19,7 @@ If the {virt} storage does not support link:https://access.redhat.com/documentat
 +
 `ReadWriteOnce` access mode does not support live virtual machine migration.
 
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/virtualization/index#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
 ====
 
 .Default volume and access modes

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -10,7 +10,7 @@
 
 [NOTE]
 ====
-If the {virt} storage does not support link:https://docs.openshift.com/container-platform/{ocp-version}/storage/dynamic-provisioning.html[dynamic provisioning], {project-short} applies the default settings:
+If the {virt} storage does not support link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/storage/index#dynamic-provisioning[dynamic provisioning], you must apply the following settings:
 
 * `Filesystem` volume mode
 +
@@ -18,6 +18,8 @@ If the {virt} storage does not support link:https://docs.openshift.com/container
 * `ReadWriteOnce` access mode
 +
 `ReadWriteOnce` access mode does not support live virtual machine migration.
+
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/virtualization/index#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
 ====
 
 .Default volume and access modes

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -21,7 +21,7 @@ ifeval::["{build}" == "upstream"]
 See link:https://docs.okd.io/latest/operators/admin/olm-upgrading-operators.html#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
 endif::[]
 ifeval::["{build}" == "downstream"]
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/operators/index#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
 endif::[]
 
 . Restart the `CatalogSource` pod:
@@ -54,7 +54,7 @@ ifeval::["{build}" == "upstream"]
 See link:https://docs.okd.io/latest/operators/admin/olm-upgrading-operators.html#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending upgrade] in the {ocp} documentation.
 endif::[]
 ifeval::["{build}" == "downstream"]
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/operators/index#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending upgrade] in the {ocp} documentation.
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending upgrade] in the {ocp} documentation.
 endif::[]
 
 . Verify that the `forklift-ui` pod is in a `Ready` state before you log in to the web console:


### PR DESCRIPTION
DO NOT MERGE BEFORE 2.3 RELEASE

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2037652

This applies to 2.3 and later.

Updated note for 2.3, such that what was previously a default setting needs to be configured in 2.3.

Preview:
https://deploy-preview-284--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#about-storage_forklift