### PR TITLE
2050713 - [Doc] "Obtaining the MTV web console URL" requires more information/clarity

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -55,18 +55,18 @@ You can install the {operator-name} by using the {ocp} web console or the comman
 :web:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-[discrete]
-include::modules/obtaining-console-url.adoc[leveloffset=+3]
+// [discrete]
+// include::modules/obtaining-console-url.adoc[leveloffset=+2]
 :!web:
 :context: cli
 :cli:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-[discrete]
-include::modules/obtaining-console-url.adoc[leveloffset=+3]
+// [discrete]
 :!cli:
 :context: mtv
 :mtv:
+include::modules/obtaining-console-url.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]
 == Migrating virtual machines by using the {project-short} web console

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -59,19 +59,14 @@ You can install the {operator-name} by using the {ocp} web console or the comman
 :web:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-[discrete]
-include::modules/obtaining-console-url.adoc[leveloffset=+3]
 :!web:
 :context: cli
 :cli:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-[discrete]
-include::modules/obtaining-console-url.adoc[leveloffset=+3]
 :!cli:
 :context: mtv
 :mtv:
-
 include::modules/obtaining-console-url.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]
@@ -120,7 +115,7 @@ You can migrate virtual machines to {virt} from the command line.
 ====
 *  You must be logged in as a user with `cluster-admin` privileges.
 
-*  VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
+//*  VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
 
 *  VMware only: You must have the xref:obtaining-vmware-fingerprint_{context}[vCenter SHA-1 fingerprint].
 

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -42,7 +42,11 @@ include::modules/source-vm-prerequisites.adoc[leveloffset=+2]
 include::modules/rhv-prerequisites.adoc[leveloffset=+2]
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
+:context: prereqs
+:prereqs:
 include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+3]
+:context: mtv
+:mtv:
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
 
 [id="installing-the-operator"]

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -55,17 +55,19 @@ You can install the {operator-name} by using the {ocp} web console or the comman
 :web:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-// [discrete]
-// include::modules/obtaining-console-url.adoc[leveloffset=+2]
+[discrete]
+include::modules/obtaining-console-url.adoc[leveloffset=+3]
 :!web:
 :context: cli
 :cli:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
-// [discrete]
+[discrete]
+include::modules/obtaining-console-url.adoc[leveloffset=+3]
 :!cli:
 :context: mtv
 :mtv:
+
 include::modules/obtaining-console-url.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -143,3 +143,6 @@ forklift-operator-6bf45b8d8-qps9v     1/1    Running  0         5m
 forklift-ui-7cdf96d8f6-xnw5n          1/1    Running  0         2m
 ----
 endif::[]
+
+.Additional resources
+* xref:obtaining-console-url_mtv[Getting the {project-short} web console URL]

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -40,6 +40,7 @@ endif::[]
 . Under *Provided APIs*, locate the *ForkliftController*, and click *Create Instance*.
 . Click *Create*.
 . Click *Workloads* -> *Pods* to verify that the {project-short} pods are running.
+include::snippet_getting_web_console_url_web.adoc[]
 endif::[]
 ifdef::cli[]
 
@@ -142,4 +143,5 @@ forklift-controller-788bdb4c69-mw268  2/2    Running  0         2m
 forklift-operator-6bf45b8d8-qps9v     1/1    Running  0         5m
 forklift-ui-7cdf96d8f6-xnw5n          1/1    Running  0         2m
 ----
+include::snippet_getting_web_console_url_cli.adoc[]
 endif::[]

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -143,6 +143,3 @@ forklift-operator-6bf45b8d8-qps9v     1/1    Running  0         5m
 forklift-ui-7cdf96d8f6-xnw5n          1/1    Running  0         2m
 ----
 endif::[]
-
-.Additional resources
-* xref:obtaining-console-url_mtv[Getting the {project-short} web console URL]

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -4,46 +4,24 @@
 
 :_content-type: PROCEDURE
 [id="obtaining-console-url_{context}"]
-ifeval::[{context} == "mtv"]
 = Getting the {project-short} web console URL
 
-You can get the {project-short} web console URL by using either the {ocp} web console, or the command line.
+You can get the {project-short} web console URL at any time by using either the {ocp} web console, or the command line.
 
 .Prerequisites
 
-* You must have the {virt} Operator installed.
-* You must have the {operator-name} installed.
+* {virt} Operator installed.
+* {operator-name} installed.
 * You must be logged in as a user with `cluster-admin` privileges.
 
-.Procedure
-endif::[]
-ifeval::[{context} != "mtv"]
-Now you can get the web console URL:
-endif::[]
-* If you are using the {ocp} web console, follow these steps:
-+
-.. Log in to the {ocp} web console.
-.. Click *Networking* -> *Routes*.
-.. Select the +{namespace}+ project in the *Project:* list.
-+
-The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
-+
-Click the URL to navigate to the {project-short} web console.
 
-* If you are using the command line: get the {project-short} web console URL with the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ {oc} get route virt -n {namespace} \
-  -o custom-columns=:.spec.host
-----
-+
-The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
-+
-.Example output
-[source,terminal,subs="attributes+"]
-----
-https://virt-{namespace}.apps.cluster.openshift.com.
-----
+.Procedure
+* If you are using the {ocp} web console, follow these steps:
+
+include::snippet_getting_web_console_url_web.adoc[]
+
+* If you are using the command line, get the {project-short} web console URL with the following command:
+
+include::snippet_getting_web_console_url_cli.adoc[]
 
 You can now launch a browser and navigate to the {project-short} web console.

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -4,14 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="obtaining-console-url_{context}"]
-= Obtaining the {project-short} web console URL
+= Getting the {project-short} web console URL
 
-ifdef::web[]
-You can obtain the {project-short} web console URL by using the {ocp} web console.
-endif::[]
-ifdef::cli[]
-You can obtain the {project-short} web console URL from the command line.
-endif::[]
+You can get the {project-short} web console URL by using either the {ocp} web console, or the command line.
 
 .Prerequisites
 
@@ -21,14 +16,16 @@ endif::[]
 
 .Procedure
 
-ifdef::web[]
+* If you are using the {ocp} web console, follow these steps:
 . Log in to the {ocp} web console.
 . Click *Networking* -> *Routes*.
 . Select the +{namespace}+ project in the *Project:* list.
-. Click the URL for the `forklift-ui` service to open the login page for the {project-short} web console.
-endif::[]
-ifdef::cli[]
-. Obtain the {project-short} web console URL:
++
+The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
++
+Click the URL to navigate to the {project-short} web console.
+
+* If you are using the command line: get the {project-short} web console URL with the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -36,11 +33,12 @@ $ {oc} get route virt -n {namespace} \
   -o custom-columns=:.spec.host
 ----
 +
+The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
++
 .Example output
 [source,terminal,subs="attributes+"]
 ----
 https://virt-{namespace}.apps.cluster.openshift.com.
 ----
 
-. Launch a browser and navigate to the {project-short} web console.
-endif::[]
+Launch a browser and navigate to the {project-short} web console.

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -18,7 +18,7 @@ You can get the {project-short} web console URL by using either the {ocp} web co
 .Procedure
 endif::[]
 ifeval::[{context} != "mtv"]
-. Get the web console URL:
+Now you can get the web console URL:
 endif::[]
 * If you are using the {ocp} web console, follow these steps:
 +

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -4,20 +4,19 @@
 
 :_content-type: PROCEDURE
 [id="obtaining-console-url_{context}"]
+ifeval::[{context} == "mtv"]
 = Getting the {project-short} web console URL
 
 You can get the {project-short} web console URL by using either the {ocp} web console, or the command line.
 
-ifeval::[{context} == "mtv"]
 .Prerequisites
 
 * You must have the {virt} Operator installed.
 * You must have the {operator-name} installed.
 * You must be logged in as a user with `cluster-admin` privileges.
-endif::[]
 
 .Procedure
-
+endif::[]
 * If you are using the {ocp} web console, follow these steps:
 . Log in to the {ocp} web console.
 . Click *Networking* -> *Routes*.

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -17,10 +17,14 @@ You can get the {project-short} web console URL by using either the {ocp} web co
 
 .Procedure
 endif::[]
+ifeval::[{context} != "mtv"]
+. Get the web console URL:
+endif::[]
 * If you are using the {ocp} web console, follow these steps:
-. Log in to the {ocp} web console.
-. Click *Networking* -> *Routes*.
-. Select the +{namespace}+ project in the *Project:* list.
++
+.. Log in to the {ocp} web console.
+.. Click *Networking* -> *Routes*.
+.. Select the +{namespace}+ project in the *Project:* list.
 +
 The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
 +
@@ -42,4 +46,4 @@ The URL for the `forklift-ui` service that opens the login page for the {project
 https://virt-{namespace}.apps.cluster.openshift.com.
 ----
 
-Launch a browser and navigate to the {project-short} web console.
+You can now launch a browser and navigate to the {project-short} web console.

--- a/documentation/modules/obtaining-console-url.adoc
+++ b/documentation/modules/obtaining-console-url.adoc
@@ -8,11 +8,13 @@
 
 You can get the {project-short} web console URL by using either the {ocp} web console, or the command line.
 
+ifeval::[{context} == "mtv"]
 .Prerequisites
 
 * You must have the {virt} Operator installed.
 * You must have the {operator-name} installed.
 * You must be logged in as a user with `cluster-admin` privileges.
+endif::[]
 
 .Procedure
 

--- a/documentation/modules/snippet_getting_web_console_url_cli.adoc
+++ b/documentation/modules/snippet_getting_web_console_url_cli.adoc
@@ -1,0 +1,17 @@
+ifdef::cli[]
+. Get the Forklift web console URL with the following command:
+endif::[]
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} get route virt -n {namespace} \
+  -o custom-columns=:.spec.host
+----
++
+The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+https://virt-{namespace}.apps.cluster.openshift.com.
+----

--- a/documentation/modules/snippet_getting_web_console_url_web.adoc
+++ b/documentation/modules/snippet_getting_web_console_url_web.adoc
@@ -1,0 +1,7 @@
+. Log in to the {ocp} web console.
+. Click *Networking* -> *Routes*.
+. Select the +{namespace}+ project in the *Project:* list.
++
+The URL for the `forklift-ui` service that opens the login page for the {project-short} web console is displayed.
++
+Click the URL to navigate to the {project-short} web console.


### PR DESCRIPTION
2.2, 2.3

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2050713

Moved the section "Obtaining the MTV web console URL" one level higher in TOC, removed prerequisites from installation modules, and added it as a standalone module to take into account users accessing the info day 2 and forward.

Preview: https://deploy-preview-285--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#installing-the-operator