### PR TITLE
2061650 Update "MTV upgrade" section in documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,6 @@ asciidoctor:
   - must-gather=quay.io/konveyor/forklift-must-gather:latest
   - namespace=konveyor-forklift
   - operator=forklift-operator
-  - operator-name-ui=Forklift Operator
   - operator-name=Forklift Operator
   - project-short=Forklift
   - project-full=Forklift
@@ -64,6 +63,7 @@ asciidoctor:
   - project-z-version=2.2.0
   - the-lc=
   - the=
+  - experimental
   safe: unsafe
 
 exclude:

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ asciidoctor:
   - must-gather=quay.io/konveyor/forklift-must-gather:latest
   - namespace=konveyor-forklift
   - operator=forklift-operator
+  - operator-name-ui=Forklift Operator
   - operator-name=Forklift Operator
   - project-short=Forklift
   - project-full=Forklift

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -9,6 +9,7 @@
 :ocp-version: 4.9
 :ocp-short: OCP
 :operator: mtv-operator
+:operator-name-ui: Migration Tookit for Virtualization Operator
 :operator-name: MTV Operator
 :project-full: Migration Toolkit for Virtualization
 :project-short: MTV

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -33,10 +33,10 @@ ifeval::["{build}" == "upstream"]
 The {operator-name} is a Community Operator. Red Hat does not support Community Operators.
 ====
 endif::[]
-. Click the {operator-name} and then click *Install*.
+. Click *{operator-name-ui}* and then click *Install*.
 . On the *Install Operator* page, click *Install*.
-. Click *Operators* -> *Installed Operators* to verify that the {operator-name} appears in the *{namespace}* project with the status *Succeeded*.
-. Click the {operator-name}.
+. Click *Operators* -> *Installed Operators* to verify that *{operator-name-ui}* appears in the *{namespace}* project with the status *Succeeded*.
+. Click *{operator-name-ui}*.
 . Under *Provided APIs*, locate the *ForkliftController*, and click *Create Instance*.
 . Click *Create*.
 . Click *Workloads* -> *Pods* to verify that the {project-short} pods are running.

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -15,7 +15,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name} Operator>Subscription].
+. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name-ui}>Subscription].
 
 . Change the update channel to *release-v2.2.0*.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -15,7 +15,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name} Operator>Subscription].
+. In the {ocp-short} web console, click *Operators*->*Installed Operators*->*{operator-name}*->*Subscription*.
 
 . Change the update channel to *release-v2.2.0*.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -15,7 +15,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click menu:Operators[Installed Operators>Subscription].
+. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name} Operator>Subscription].
 
 . Change the update channel to *release-v2.2.0*.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -15,6 +15,8 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
+. Click the *Subscriptions* tab of the *Operator details* page in the {ocp-short} web console.
+
 . Change the update channel to *release-v2.2.0*.
 +
 ifeval::["{build}" == "upstream"]
@@ -24,11 +26,9 @@ ifeval::["{build}" == "downstream"]
 See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/operators/index#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
 endif::[]
 
-. On the *Subscriptions* tab of the *Operator details* page in the {ocp-short} web console, confirm that *Upgrade status* changes from *Up to date* to *Upgrade available*. If it does not, restart the `CatalogSource` pod:
+. Confirm that *Upgrade status* changes from *Up to date* to *Upgrade available*. If it does not, restart the `CatalogSource` pod:
 
-.. In the the {ocp-short} web console, click *Operators* -> *Installed Operators*. Click *Forklift Operator* to view the *Operator details* page.
-
-..  On the *Subscriptions* tab, note the catalog source, for example, `redhat-operators`.
+..  Note the catalog source, for example, `redhat-operators`.
 ..  From the command line, retrieve the catalog source pod:
 +
 [source,terminal,subs=attributes+]
@@ -44,7 +44,7 @@ $ {oc} get pod -n openshift-marketplace | grep <catalog_source> <1>
 $ {oc} delete pod -n openshift-marketplace <catalog_source_pod>
 ----
 +
-On the *Subscriptions* tab of the *Operator details* page in the {ocp-short} web console, *Upgrade status* changes from *Up to date* to *Upgrade available*.
+*Upgrade status* changes from *Up to date* to *Upgrade available*.
 +
 If you set *Update approval* on the *Subscriptions* tab to *Automatic*, the upgrade starts automatically.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -15,7 +15,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. Click the *Subscriptions* tab of the *Operator details* page in the {ocp-short} web console.
+. In the {ocp-short} web console, click menu:Operators[Installed Operators>Subscription].
 
 . Change the update channel to *release-v2.2.0*.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
-
+:experimental:
 :_content-type: PROCEDURE
 [id="upgrading-mtv-ui_{context}"]
 = Upgrading {the-lc} {project-full}
@@ -15,7 +15,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name-ui}>Subscription].
+. In the {ocp-short} web console, click menu:Operators[Installed Operators>{operator-name} Operator>Subscription].
 
 . Change the update channel to *release-v2.2.0*.
 +

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -24,7 +24,7 @@ ifeval::["{build}" == "downstream"]
 See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html-single/operators/index#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
 endif::[]
 
-. Restart the `CatalogSource` pod:
+. On the *Subscriptions* tab of the *Operator details* page in the {ocp-short} web console, confirm that *Upgrade status* changes from *Up to date* to *Upgrade available*. If it does not, restart the `CatalogSource` pod:
 
 .. In the the {ocp-short} web console, click *Operators* -> *Installed Operators*. Click *Forklift Operator* to view the *Operator details* page.
 

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
-:experimental:
 :_content-type: PROCEDURE
 [id="upgrading-mtv-ui_{context}"]
 = Upgrading {the-lc} {project-full}
@@ -15,7 +14,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click *Operators*->*Installed Operators*->*{operator-name}*->*Subscription*.
+. In the {ocp-short} web console, click *Operators* -> *Installed Operators* -> *{operator-name-ui}* -> *Subscription*.
 
 . Change the update channel to *release-v2.2.0*.
 +


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2061650

Target MTV 2.2.

Preview:
https://deploy-preview-286--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#upgrading-mtv-ui_forklift

