### PR TITLE
Split "Adding Providers" in the MTV user guide into source providers and destination providers 

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -82,22 +82,33 @@ You can migrate virtual machines (VMs) to {virt} by using the {project-short} we
 [id="adding-providers"]
 === Adding providers
 
-You can add providers by using the {project-short} web console.
+You can add source providers and destination providers for a virtual machine migration by using the {project-short} web console.
+
+[id="adding-source-providers"]
+==== Adding source providers
+
+You can add {a-rhv} source provider or a VMware source provider by using the {project-short} web console.
 
 :mtv!:
 :context: vmware
 :vmware:
-include::modules/adding-source-provider.adoc[leveloffset=+3]
+include::modules/adding-source-provider.adoc[leveloffset=+4]
 :vmware!:
 :context: rhv
 :rhv:
-include::modules/adding-source-provider.adoc[leveloffset=+3]
+include::modules/adding-source-provider.adoc[leveloffset=+4]
 :rhv!:
 :context: mtv
 :mtv:
-include::modules/selecting-migration-network-for-source-provider.adoc[leveloffset=+3]
-include::modules/adding-virt-provider.adoc[leveloffset=+3]
-include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+3]
+include::modules/selecting-migration-network-for-source-provider.adoc[leveloffset=+4]
+
+[id="adding-destination-providers"]
+==== Adding destination providers
+
+You can add  a {virt} destination provider by using the {project-short} web console.
+
+include::modules/adding-virt-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
 
 include::modules/creating-network-mapping.adoc[leveloffset=+2]
 include::modules/creating-storage-mapping.adoc[leveloffset=+2]

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="adding-virt-provider_{context}"]
-= Adding {a-virt} provider
+= Adding {a-virt} destination provider
 
-You can add {a-virt} provider to the {project-short} web console in addition to the default {virt} provider, which is the provider where you installed {project-short}.
+You can add {a-virt} destination provider to the {project-short} web console in addition to the default {virt} destination provider, which is the provider where you installed {project-short}.
 
 .Prerequisites
 


### PR DESCRIPTION
MTV 2.2

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2050724

Splits the "Adding Providers" in _Installing and using the Migration Toolkit for Virtualization_ into two subsections, _Adding source providers_ and _Adding destination providers_.

Preview: https://deploy-preview-292--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#adding-providers