### PR TITLE
Replace "www.example.com" with "fqdn" in MTV repo

### DIFF
--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -121,7 +121,5 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
-<3> Specify the name of provider `Secret` CR.
-
-You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<RHV engine host>/ovirt-engine/api/` for {rhv-short}.
+<3> Specify the name of the provider `Secret` CRHV engine host. You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -121,7 +121,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<www.example.com>/sdk` for vSphere or `https://<www.example.com>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -122,6 +122,6 @@ EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
 <2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<{rhv-short}_engine_host>/ovirt-engine/api/` for {rhv-short}.
-<3> Specify the name of the provider `Secret` CR. 
-+
+<3> Specify the name of the provider `Secret` CR.
+
 You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -121,5 +121,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<RHV engine host>/ovirt-engine/api/` for {rhv-short}.
-<3> Specify the name of the provider `Secret` CRHV engine host. You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<{rhv-short}_engine_host>/ovirt-engine/api/` for {rhv-short}.
+<3> Specify the name of the provider `Secret` CR. 
++
+You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -57,7 +57,7 @@ EOF
 ----
 <1> Specify the base64-encoded vCenter user or the {rhv-short} {manager} user.
 <2> Specify the base64-encoded password.
-<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<www.example.com>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -79,7 +79,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<www.example.com>/sdk` for vSphere or `https://<www.example.com>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 . VMware only: Create a `Host` manifest:

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -57,7 +57,7 @@ EOF
 ----
 <1> Specify the base64-encoded vCenter user or the {rhv-short} {manager} user.
 <2> Specify the base64-encoded password.
-<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<RHV engine host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -79,7 +79,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<RHV engine host>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<{rhv-short}_engine_host>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 . VMware only: Create a `Host` manifest:

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -57,7 +57,7 @@ EOF
 ----
 <1> Specify the base64-encoded vCenter user or the {rhv-short} {manager} user.
 <2> Specify the base64-encoded password.
-<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<RHV engine host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -79,7 +79,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<RHV engine host>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 . VMware only: Create a `Host` manifest:

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -132,7 +132,7 @@ $ GET https://<inventory_service_route>/providers/<provider>/<UUID>/workloads/<v
                 "id": "domain-c26"
             },
             "revision": 1,
-            "name": "fqdn",
+            "name": "IP address or host name of the vCenter host or RHV Engine host",
             "selfLink": "providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts/host-29",
             "status": "green",
             "inMaintenance": false,

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -132,7 +132,7 @@ $ GET https://<inventory_service_route>/providers/<provider>/<UUID>/workloads/<v
                 "id": "domain-c26"
             },
             "revision": 1,
-            "name": "IP address or host name of the vCenter host or RHV Engine host",
+            "name": "IP address or host name of the vCenter host or {rhv-short}_engine_host",
             "selfLink": "providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts/host-29",
             "status": "green",
             "inMaintenance": false,

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -132,7 +132,7 @@ $ GET https://<inventory_service_route>/providers/<provider>/<UUID>/workloads/<v
                 "id": "domain-c26"
             },
             "revision": 1,
-            "name": "www.example.com",
+            "name": "fqdn",
             "selfLink": "providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts/host-29",
             "status": "green",
             "inMaintenance": false,

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -132,7 +132,7 @@ $ GET https://<inventory_service_route>/providers/<provider>/<UUID>/workloads/<v
                 "id": "domain-c26"
             },
             "revision": 1,
-            "name": "IP address or host name of the vCenter host or {rhv-short}_engine_host",
+            "name": "IP address or host name of the vCenter host or {rhv-short} Engine host",
             "selfLink": "providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts/host-29",
             "status": "green",
             "inMaintenance": false,

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -10,4 +10,4 @@ The following prerequisites apply to {rhv-full} migrations:
 
 * You must have the CA certificate of the {manager}.
 +
-You can obtain the CA certificate by navigating to `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
+You can obtain the CA certificate by navigating to `https://<RHV engine host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -10,4 +10,4 @@ The following prerequisites apply to {rhv-full} migrations:
 
 * You must have the CA certificate of the {manager}.
 +
-You can obtain the CA certificate by navigating to `https://<www.example.com>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
+You can obtain the CA certificate by navigating to `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -10,4 +10,4 @@ The following prerequisites apply to {rhv-full} migrations:
 
 * You must have the CA certificate of the {manager}.
 +
-You can obtain the CA certificate by navigating to `https://<RHV engine host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
+You can obtain the CA certificate by navigating to `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.


### PR DESCRIPTION
MTV 2.2+

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2067152

Replaces "www.example.com" in MTV documentation. 