### PR TITLE
Removed "base64-encoded" from note 3 of step 1 of "Migrating VM" procedure

### DIFF
--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -43,7 +43,7 @@ EOF
 ----
 <1> Specify the vCenter user or the {rhv-short} {manager} user.
 <2> Specify the user password.
-<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:


### PR DESCRIPTION
Fixes error in https://github.com/konveyor/forklift-documentation/pull/315. 

Removes "base64-encoded" from note 3 of step 1 of "Migrating VM" procedure

Preview: https://deploy-preview-316--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#migrating-virtual-machines-cli_forklift