### PR TITLE
Solves repeated callout

### DIFF
--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -32,9 +32,8 @@ endif::[]
 +
 [source,shell,subs="attributes+"]
 ----
-$ {oc} get pod -n openshift-marketplace | grep <catalog_source> <1>
+$ {oc} get pod -n openshift-marketplace | grep <catalog_source>
 ----
-<1> Specify the catalog source, for example, `redhat-operators`.
 
 ..  Delete the pod:
 +


### PR DESCRIPTION
MTV 2.3

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2066604

It was decided by Avital and Richard that the callout was not needed because the text before the code block and code block itself were clear enough as is. 

Preview: https://deploy-preview-321--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#upgrading-mtv-ui_forklift