### PR TITLE
Replace [souce,shell..} with [source, terminal..] in repo

### DIFF
--- a/documentation/modules/canceling-migration-cli.adoc
+++ b/documentation/modules/canceling-migration-cli.adoc
@@ -12,7 +12,7 @@ You can cancel an entire migration or individual virtual machines (VMs) while a 
 
 * Delete the `Migration` CR:
 +
-[source,shell,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} delete migration <migration> -n {namespace} <1>
 ----
@@ -44,7 +44,7 @@ The value of the `id` key is the _managed object reference_, for a VMware VM, or
 
 . Retrieve the `Migration` CR to monitor the progress of the remaining VMs:
 +
-[source,shell,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} get migration/<migration> -n {namespace} -o yaml
 ----

--- a/documentation/modules/changing-precopy-intervals.adoc
+++ b/documentation/modules/changing-precopy-intervals.adoc
@@ -12,7 +12,7 @@ You can change the snapshot interval by patching the `ForkliftController` custom
 
 * Patch the `ForkliftController` CR:
 +
-[source,shell,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} patch forkliftcontroller/<forklift-controller> -n {namespace} -p '{"spec": {"controller_precopy_interval": <60>}}' --type=merge <1>
 ----

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -30,7 +30,7 @@ endif::[]
 ..  Note the catalog source, for example, `redhat-operators`.
 ..  From the command line, retrieve the catalog source pod:
 +
-[source,shell,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} get pod -n openshift-marketplace | grep <catalog_source> <1>
 ----
@@ -38,7 +38,7 @@ $ {oc} get pod -n openshift-marketplace | grep <catalog_source> <1>
 
 ..  Delete the pod:
 +
-[source,shell,subs=attributes+]
+[source,terminal,subs=attributes+]
 ----
 $ {oc} delete pod -n openshift-marketplace <catalog_source_pod>
 ----
@@ -58,7 +58,7 @@ endif::[]
 
 . Verify that the `forklift-ui` pod is in a `Ready` state before you log in to the web console:
 +
-[source,shell,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} get pods -n {namespace}
 ----


### PR DESCRIPTION
MTV 2.3

In some files, the block metadata began with [source,shell...] instead of the previous [source,terminal...]. After consulting with Avital Pinnick, I've decided to revert the changes in order to maintain consistency in the repo and the larger document set. 