### PR TITLE
BZ2078360{rhv-short} appears instead of RHV in MTV documentation

### DIFF
--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -121,7 +121,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<{rhv-short}_engine_host>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of the provider `Secret` CR.
 
 You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -36,7 +36,7 @@ stringData:
   user: <user> <1>
   password: <password> <2>
   cacert: | <3>
-    <{rhv_ca_certificate>
+    <engine_ca_certificate>
   thumbprint: <vcenter_fingerprint> <4>
 EOF
 ----
@@ -66,7 +66,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
+<2> s, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
 <3> VMware only: Specify the VDDK image that you created.
 <4> Specify the name of provider `Secret` CR.
 

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -36,13 +36,13 @@ stringData:
   user: <user> <1>
   password: <password> <2>
   cacert: | <3>
-    <{rhv-short}_ca_certificate>
+    <{rhv_ca_certificate>
   thumbprint: <vcenter_fingerprint> <4>
 EOF
 ----
 <1> Specify the vCenter user or the {rhv-short} {manager} user.
 <2> Specify the user password.
-<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -66,7 +66,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<{rhv-short}_engine_host>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
 <3> VMware only: Specify the VDDK image that you created.
 <4> Specify the name of provider `Secret` CR.
 

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -66,7 +66,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> s, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere or `https://<engine_host>/ovirt-engine/api/` for {rhv-short}.
 <3> VMware only: Specify the VDDK image that you created.
 <4> Specify the name of provider `Secret` CR.
 

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -42,7 +42,7 @@ $ GET https://<inventory_service_route>/providers/<provider>/<UUID>/workloads/<v
 ----
 +
 .Example output
-[source,yaml]
+[source,yaml,subs="attributes+"]]
 ----
 {
     "input": {

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -10,4 +10,4 @@ The following prerequisites apply to {rhv-full} migrations:
 
 * You must have the CA certificate of the {manager}.
 +
-You can obtain the CA certificate by navigating to `https://<{rhv-short}_engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
+You can obtain the CA certificate by navigating to `https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.


### PR DESCRIPTION
MTV 2.2 and 2.3

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2078360

In some places in the MTV documentation the attribute {rhv-short} appears instead of RHV.  This PR fixes that problem. 
It turned out that due to Red hat writing conventions and the fact that this PR must serve the upstream community, replacing {rhv-short} with RHV was not the best answer either. 

Previews:
1. _RHV prerequisites_: https://deploy-preview-326--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#rhv-prerequisites_forklift 
2. _Migrating virtual machines_: https://deploy-preview-326--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#migrating-virtual-machines-cli_forklift 
3. _Retrieving the Inventory service JSON_ : https://deploy-preview-326--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#retrieving-validation-service-json_forklift [Example output]
4. _Validation rule example_: https://deploy-preview-326--forklift-documentation.netlify.app/documentation/doc-migration_toolkit_for_virtualization/master/#creating-validation-rule_forklift[_Validation rule_, step 6, note 2] 